### PR TITLE
feat: generate unique ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "through2": "^4.0.2"
       },
       "peerDependencies": {
-        "vue": "v2-latest"
+        "vue": ">=2.6"
       }
     },
     "node_modules/@achrinza/node-ipc": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "through2": "^4.0.2"
   },
   "peerDependencies": {
-    "vue": "v2-latest"
+    "vue": ">=2.6"
   },
   "repository": "git@github.com:dialpad/dialtone-icons.git"
 }

--- a/src/baseIconTemplate.vue
+++ b/src/baseIconTemplate.vue
@@ -1,0 +1,13 @@
+<template>
+/*SVG-CONTENT*/
+</template>
+
+<script>
+import { getUniqueString } from "@/utils";
+
+export default {
+  created () {
+    this.uniqueID = getUniqueString();
+  },
+}
+</script>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,10 @@
+export const DEFAULT_PREFIX = 'dtIcon';
+let UNIQUE_ID_COUNTER = 0;
+
+export function getUniqueString (prefix = DEFAULT_PREFIX) {
+  return `${prefix}${UNIQUE_ID_COUNTER++}`;
+}
+
+export default {
+  getUniqueString,
+}


### PR DESCRIPTION
Added the functionality to prefix a unique id to all fills, filters, clip-paths and masks of the svgs.

This prevents the error of having duplicated ids https://stackoverflow.com/questions/36426286/svg-linked-from-same-svg-file-causes-one-to-disappear/67625148#67625148